### PR TITLE
Fixed small bugs.

### DIFF
--- a/src/BlazorGPT/Pages/ConversationPage.razor.cs
+++ b/src/BlazorGPT/Pages/ConversationPage.razor.cs
@@ -271,7 +271,8 @@ namespace BlazorGPT.Pages
 
             try
             {
-                var strs = await LocalStorageService.GetItemAsync<List<string>>("bgpt_interceptors");
+                var hasKey = await LocalStorageService.ContainKeyAsync("bgpt_interceptors");
+                var strs = hasKey ? await LocalStorageService.GetItemAsync<List<string>>("bgpt_interceptors") : [];
 
                 Conversation = await InterceptorHandler.Send(_kernel,
                     Conversation, 

--- a/src/BlazorGPT/Pipeline/KernelService.cs
+++ b/src/BlazorGPT/Pipeline/KernelService.cs
@@ -66,13 +66,13 @@ public class KernelService
 #pragma warning disable SKEXP0011
             builder
             .AddAzureOpenAIChatCompletion(
-                deploymentName: _options.Providers.AzureOpenAI.ChatModels.First( p => p.Key == model).Key,
+                deploymentName: _options.Providers.AzureOpenAI.ChatModels.First( p => p.Value == model).Key,
                 modelId: model,
                 endpoint: _options.Providers.AzureOpenAI.Endpoint,
                 apiKey: _options.Providers.AzureOpenAI.ApiKey
                 )
             .AddAzureOpenAITextEmbeddingGeneration(
-                deploymentName: _options.Providers.AzureOpenAI.EmbeddingsModels.First(p => p.Key == _options.Providers.AzureOpenAI.EmbeddingsModel).Key,
+                deploymentName: _options.Providers.AzureOpenAI.EmbeddingsModels.First(p => p.Value == _options.Providers.AzureOpenAI.EmbeddingsModel).Key,
                 modelId: _options.Providers.AzureOpenAI.EmbeddingsModel,
                 endpoint: _options.Providers.AzureOpenAI.Endpoint,
                 apiKey: _options.Providers.AzureOpenAI.ApiKey


### PR DESCRIPTION
It was awaiting forever on the call to get bgpt_interceptors in initial install/use.
I added the check in the one place, but not the others -- I'll leave that to you to investigate or wrap, as you see fit.

When a deployment is not exactly the same name as the model, you'll be able to reproduce the key/value issue in KernelService.


