### PR TITLE
Add MaxPlannerTokens.

### DIFF
--- a/src/BlazorGPT.Web/appsettings.json
+++ b/src/BlazorGPT.Web/appsettings.json
@@ -46,6 +46,7 @@
     },
 
     "MaxTokens": 2500,
+    "MaxPlannerTokens": 1000,
     "KrokiHost": "https://kroki.io",
     "EnabledInterceptors": [ "State has changed" ],
     "PreSelectedInterceptors": [],

--- a/src/BlazorGPT/Pipeline/PipelineOptions.cs
+++ b/src/BlazorGPT/Pipeline/PipelineOptions.cs
@@ -197,6 +197,7 @@ public class PipelineOptions
     public ModelsProvidersOptions Providers { get; set; } =  new ModelsProvidersOptions();
 
     public int MaxTokens { get; set; }
+    public int MaxPlannerTokens { get; set; }
 
     public string[]? EnabledInterceptors { get; set; }
     public string[]? PreSelectedInterceptors { get; set; }

--- a/src/BlazorGPT/Settings/ModelConfiguration.cs
+++ b/src/BlazorGPT/Settings/ModelConfiguration.cs
@@ -7,6 +7,7 @@ public class ModelConfiguration
     public ChatModelsProvider Provider { get; set; }
     public string Model { get; set; } = null!;
     public int MaxTokens { get; set; }
+    public int MaxPlannerTokens { get; set; }
     public float Temperature { get; set; }
 
     public EmbeddingsModelProvider EmbeddingsProvider { get; set; }

--- a/src/BlazorGPT/Settings/ModelConfigurationService.cs
+++ b/src/BlazorGPT/Settings/ModelConfigurationService.cs
@@ -26,6 +26,7 @@ public class ModelConfigurationService
             Provider = _pipelineOptions.Providers.GetChatModelsProvider(),
             Model = _pipelineOptions.Providers.GetChatModel(),
             MaxTokens = _pipelineOptions.MaxTokens,
+            MaxPlannerTokens = _pipelineOptions.MaxPlannerTokens,
             Temperature = 0.0f,
             EmbeddingsModel = _pipelineOptions.Providers.GetEmbeddingsModel(),
             EmbeddingsProvider = _pipelineOptions.Providers.GetEmbeddingsModelProvider()


### PR DESCRIPTION
Azure OpenAI service seems to need explicit MaxToken value.  Moreover, the failure is poorly handled in the current Semantic Kernel package, see https://github.com/microsoft/semantic-kernel/issues/5934

Added MaxPlannerTokens to the PipelineOptions and flowed these values into the plugin interceptor.

I don't have enough experience with these to know if 1000 is enough or too much.

